### PR TITLE
[FEAT] Chat 화면 구현, Color+Extension, Font+Extension

### DIFF
--- a/Mentors.swiftpm/Assets.xcassets/Contents.json
+++ b/Mentors.swiftpm/Assets.xcassets/Contents.json
@@ -1,6 +1,0 @@
-{
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
-}

--- a/Mentors.swiftpm/Chat.swift
+++ b/Mentors.swiftpm/Chat.swift
@@ -1,0 +1,192 @@
+//
+//  Chat.swift
+//  Mentors
+//
+//  Created by 제나 on 2023/03/27.
+//
+
+import SwiftUI
+
+struct Chat: View {
+    
+    @FocusState private var focusMessageField
+    @State private var isMoreFunctionsShowing: Bool = false
+    @State private var message = ""
+    private let functions: [String: String] = ["photo": "앨범",
+                                       "camera": "카메라",
+                                       "folder": "파일",
+                                       "calendar": "캘린더"]
+    
+    func toggleButtons() {
+        focusMessageField = false
+    }
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                // leeo's chat
+                HStack {
+                    HStack {
+                        Circle()
+                            .frame(width: 48, height: 48)
+                            .foregroundColor(Color(hex: "D9D9D9"))
+                        
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("리이오")
+                                .font(.system(size: 10))
+                                .foregroundColor(Color(hex: "292929"))
+                                .padding(.leading, 5)
+                            Text("어떤 도움이 필요하신가요?")
+                                .font(.system(size: 14))
+                                .padding(.vertical, 5)
+                                .padding(.horizontal, 10)
+                                .background(Color(hex: "F9F9F9"))
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 10)
+                                        .stroke(Color(hex: "F6D555"), lineWidth: 1)
+                                }
+                                .foregroundColor(Color(hex: "292929"))
+                        }
+                        .padding(.leading, 5)
+                    }
+                    Spacer()
+                }
+                .padding(.leading, 16)
+                .padding(.bottom, 24)
+                
+                // LeGo's chat
+                HStack {
+                    Spacer()
+                    
+                    HStack {
+                        VStack(alignment: .trailing, spacing: 2) {
+                            Text("LeGo")
+                                .font(.system(size: 10))
+                                .foregroundColor(Color(hex: "292929"))
+                                .padding(.trailing, 5)
+                            Text("팀원들이 너무 싸워요..")
+                                .font(.system(size: 14))
+                                .padding(.vertical, 5)
+                                .padding(.horizontal, 11)
+                                .background(Color(hex: "FDF4D1"))
+                                .cornerRadius(8)
+                                .foregroundColor(Color(hex: "292929"))
+                        }
+                    }
+                }
+                .padding(.trailing, 16)
+                
+                // schedule
+                VStack(alignment: .leading) {
+                    HStack {
+                        Image(systemName: "calendar.circle.fill")
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(.white, Color(hex: "F6D555"))
+                            .font(.system(size: 20))
+                        
+                        Text("3월 31일 (금) 오후 4:00")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundColor(Color(hex: "292929"))
+                        Spacer()
+                    }
+                    .padding(.bottom, 4)
+                    .padding(.leading, 26)
+                    
+                    HStack {
+                        Text("멘토 리이오")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(Color(hex: "292929"))
+                        
+                        Text("(와)과 멘토링 약속을 잡았어요.")
+                            .font(.system(size: 14))
+                            .foregroundColor(Color(hex: "292929"))
+                    }
+                    .padding(.leading, 28)
+                }
+                .padding(.vertical, 28)
+                .background(Color(hex: "F9F9F9"))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Color(hex: "F6D555"), lineWidth: 3)
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 45)
+                
+                Spacer()
+                
+                // more functions
+                VStack {
+                    HStack {
+                        Button {
+                            if isMoreFunctionsShowing {
+                                isMoreFunctionsShowing = false
+                            } else {
+                                isMoreFunctionsShowing = true
+                                focusMessageField = false
+                            }
+                        } label: {
+                            Image(systemName: isMoreFunctionsShowing && !focusMessageField ? "minus" : "plus")
+                                .font(.system(size: 24, weight: .regular))
+                                .foregroundColor(Color(hex: "F6D555"))
+                        }
+                        
+                        ZStack {
+                            TextField("", text: $message)
+                                .frame(height: 40)
+                                .padding(.horizontal, 10)
+                                .background(Color(hex: "F5F3E9"))
+                                .opacity(0.9)
+                                .cornerRadius(20)
+                                .foregroundColor(Color(hex: "292929"))
+                                .focused($focusMessageField)
+                            
+                            if !message.isEmpty {
+                                HStack {
+                                    Spacer(minLength: 0)
+                                    
+                                    Button {
+                                        
+                                    } label: {
+                                        Image(systemName: "paperplane")
+                                            .foregroundColor(Color(hex: "F9F9F9"))
+                                            .background {
+                                                Circle()
+                                                    .frame(width: 34, height: 34)
+                                            }
+                                    }
+                                }
+                                .padding(.trailing, 11)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    
+                    if isMoreFunctionsShowing && !focusMessageField {
+                        HStack {
+                            ForEach(functions.sorted(by: >), id: \.key) { key, value in
+                                FunctionCustomView(imageName: key, functionName: value)
+                                    .frame(maxWidth: .infinity)
+                            }
+                        }
+                        .padding(.horizontal, 40)
+                        .padding(.top, 20)
+                    }
+                }
+                .background(Color(hex: "F9F9F9"))
+                .transition(.slide)
+                .animation(.easeIn)
+            }
+            .background(Color(hex: "F7F5EF"))
+        }
+        .ignoresSafeArea()
+        .navigationTitle("리이오")
+        .ignoresSafeArea()
+    }
+}
+
+struct Chat_Previews: PreviewProvider {
+    static var previews: some View {
+        Chat()
+    }
+}

--- a/Mentors.swiftpm/Chat.swift
+++ b/Mentors.swiftpm/Chat.swift
@@ -33,11 +33,12 @@ struct Chat: View {
                         
                         VStack(alignment: .leading, spacing: 2) {
                             Text("리이오")
-                                .font(.system(size: 10))
+                                .font(.sandoll(size: 10, weight: .medium))
                                 .foregroundColor(Color(hex: "292929"))
                                 .padding(.leading, 5)
                             Text("어떤 도움이 필요하신가요?")
                                 .font(.system(size: 14))
+                                .font(.sandoll(size: 14, weight: .medium))
                                 .padding(.vertical, 5)
                                 .padding(.horizontal, 10)
                                 .background(Color(hex: "F9F9F9"))
@@ -61,11 +62,11 @@ struct Chat: View {
                     HStack {
                         VStack(alignment: .trailing, spacing: 2) {
                             Text("LeGo")
-                                .font(.system(size: 10))
+                                .font(.sandoll(size: 10, weight: .medium))
                                 .foregroundColor(Color(hex: "292929"))
                                 .padding(.trailing, 5)
                             Text("팀원들이 너무 싸워요..")
-                                .font(.system(size: 14))
+                                .font(.sandoll(size: 14, weight: .medium))
                                 .padding(.vertical, 5)
                                 .padding(.horizontal, 11)
                                 .background(Color(hex: "FDF4D1"))
@@ -82,10 +83,10 @@ struct Chat: View {
                         Image(systemName: "calendar.circle.fill")
                             .symbolRenderingMode(.palette)
                             .foregroundStyle(.white, Color(hex: "F6D555"))
-                            .font(.system(size: 20))
+                            .font(.sandoll(size: 20, weight: .medium))
                         
                         Text("3월 31일 (금) 오후 4:00")
-                            .font(.system(size: 14, weight: .bold))
+                            .font(.sandoll(size: 14, weight: .bold))
                             .foregroundColor(Color(hex: "292929"))
                         Spacer()
                     }
@@ -94,11 +95,11 @@ struct Chat: View {
                     
                     HStack {
                         Text("멘토 리이오")
-                            .font(.system(size: 14, weight: .semibold))
+                            .font(.sandoll(size: 14, weight: .semibold))
                             .foregroundColor(Color(hex: "292929"))
                         
                         Text("(와)과 멘토링 약속을 잡았어요.")
-                            .font(.system(size: 14))
+                            .font(.sandoll(size: 14, weight: .medium))
                             .foregroundColor(Color(hex: "292929"))
                     }
                     .padding(.leading, 28)
@@ -127,6 +128,7 @@ struct Chat: View {
                         } label: {
                             Image(systemName: isMoreFunctionsShowing && !focusMessageField ? "minus" : "plus")
                                 .font(.system(size: 24, weight: .regular))
+                                .font(.sandoll(size: 24, weight: .regular))
                                 .foregroundColor(Color(hex: "F6D555"))
                         }
                         

--- a/Mentors.swiftpm/Color.swift
+++ b/Mentors.swiftpm/Color.swift
@@ -1,0 +1,35 @@
+//
+//  Color.swift
+//  Mentors
+//
+//  Created by 제나 on 2023/03/27.
+//
+
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (1, 1, 1, 0)
+        }
+
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue:  Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}

--- a/Mentors.swiftpm/Extensions/Color+Extension.swift
+++ b/Mentors.swiftpm/Extensions/Color+Extension.swift
@@ -1,6 +1,6 @@
 //
-//  Color.swift
-//  Mentors
+//  Color+Extension.swift
+//  Extensions
 //
 //  Created by 제나 on 2023/03/27.
 //

--- a/Mentors.swiftpm/Extensions/Font+Extension.swift
+++ b/Mentors.swiftpm/Extensions/Font+Extension.swift
@@ -1,0 +1,36 @@
+//
+//  Font+Extension.swift
+//  Extensions
+//
+//  Created by 제나 on 2023/03/28.
+//
+
+import SwiftUI
+
+extension Font {
+    static func sandoll(size fontSize: CGFloat, weight: Font.Weight) -> Font {
+            let familyName = "AppleSDGothicNeo"
+
+            var weightString: String
+            switch weight {
+            case .regular:
+                weightString = "Regular"
+            case .thin:
+                weightString = "Thin"
+            case .ultraLight:
+                weightString = "UltraLight"
+            case .light:
+                weightString = "Light"
+            case .medium:
+                weightString = "Medium"
+            case .semibold:
+                weightString = "SemiBold"
+            case .bold:
+                weightString = "Bold"
+            default:
+                weightString = "Regular"
+            }
+
+        return .custom("\(familyName)-\(weightString)", size: fontSize) ?? .system(size: fontSize, weight: weight)
+        }
+}

--- a/Mentors.swiftpm/FunctionCustomView.swift
+++ b/Mentors.swiftpm/FunctionCustomView.swift
@@ -1,0 +1,31 @@
+//
+//  FunctionCustomView.swift
+//  Mentors
+//
+//  Created by 제나 on 2023/03/28.
+//
+
+import SwiftUI
+
+struct FunctionCustomView: View {
+    
+    var imageName: String
+    var functionName: String
+    
+    var body: some View {
+        VStack {
+            
+            Circle()
+                .fill(Color(hex: "FDF4D1"))
+                .frame(width: 50, height: 50)
+                .overlay {
+                    Image(systemName: "\(imageName)")
+                        .font(.system(size: 24))
+                        .foregroundColor(Color(hex: "292929"))
+                    }
+            Text("\(functionName)")
+                .font(.system(size: 12))
+                .foregroundColor(Color(hex: "292929"))
+        }
+    }
+}

--- a/Mentors.swiftpm/Package.swift
+++ b/Mentors.swiftpm/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
             displayVersion: "1.0",
             bundleVersion: "1",
             appIcon: .placeholder(icon: .carrot),
-            accentColor: .asset("AccentColor"),
+            accentColor: .presetColor(.yellow),
             supportedDeviceFamilies: [
                 .pad,
                 .phone


### PR DESCRIPTION
## Description
- 리이오와의 채팅화면 구현
- Color를 hex 코드로 지정할 수 있는 함수 구현. 아래와 같이 사용 가능
`Color(hex: "292929")`
- 산돌고딕 네오 폰트를 쉽게 설정할 수 있는 함수 구현. 아래처럼 사용.
`.font(.sandoll(size: 14, weight: medium))`

<img width="368" alt="스크린샷 2023-03-28 오후 3 29 18" src="https://user-images.githubusercontent.com/57654681/228149769-b7caa488-0433-455f-b53f-372dcdf8e1fb.png">

## GIF

![Simulator Screen Recording - iPhone 14 Pro - 2023-03-28 at 15 37 12](https://user-images.githubusercontent.com/57654681/228149847-eccb04b5-5047-451d-8b4c-578b17510bbc.gif)

