### PR TITLE
[FEAT] popToRootView, 미팅 생성 후 멘토링 기록 버튼 visible, 멘토 확정 팝업, 멘토링 상황 재현 UI

### DIFF
--- a/Mentors.swiftpm/Chat.swift
+++ b/Mentors.swiftpm/Chat.swift
@@ -20,6 +20,7 @@ struct Chat: View {
                                        "calendar": "캘린더"]
     @State private var showNextMessage: Int = 0
     @State private var showTabBarButton: Bool = false
+    @Binding var isShowRecordButton: Bool
     
     private let avPlayer: [AVPlayer] = [
         AVPlayer(url:  Bundle.main.url(forResource: "chat1", withExtension: "mp4")!),
@@ -249,6 +250,7 @@ struct Chat: View {
                                                 avPlayer[1].play()
                                                 avPlayer[2].pause()
                                             } else if showNextMessage >= 2 {
+                                                self.isShowRecordButton = true
                                                 avPlayer[0].pause()
                                                 avPlayer[1].pause()
                                                 avPlayer[2].seek(to: .zero)
@@ -306,11 +308,5 @@ struct Chat: View {
         } else {
             // Fallback on earlier versions
         }
-    }
-}
-
-struct Chat_Previews: PreviewProvider {
-    static var previews: some View {
-        Chat()
     }
 }

--- a/Mentors.swiftpm/Chat.swift
+++ b/Mentors.swiftpm/Chat.swift
@@ -29,8 +29,7 @@ struct Chat: View {
     func toggleButtons() {
         focusMessageField = false
     }
-    
-    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+
     var btnBack : some View {
         Button(action: {
             showTabBarButton = true
@@ -38,7 +37,7 @@ struct Chat: View {
             HStack {
                 Image(systemName: "chevron.backward")
                     .aspectRatio(contentMode: .fit)
-                    .foregroundColor(Color(red: 0.1607843137254902, green: 0.1607843137254902, blue: 0.1607843137254902))
+                    .foregroundColor(.black)
             }
         }
     }
@@ -75,7 +74,7 @@ struct Chat: View {
                         Spacer()
                     }
                     .padding(.leading, 16)
-                    .padding(.bottom, 24)
+                    .padding(.vertical, 24)
                     
                     // LeGo's chat
                     if showNextMessage >= 1 {
@@ -88,7 +87,7 @@ struct Chat: View {
                                         .font(.sandoll(size: 10, weight: .medium))
                                         .foregroundColor(Color(hex: "292929"))
                                         .padding(.trailing, 5)
-                                    Text("안녕하세요, Leeo. 저희의 사연에 응답해 주셔서 감사합니다. 저희는 지금 콜랩에 있습니다. 지금 당장 가능합니다.")
+                                    Text("안녕하세요, Leeo. 저희의 사연에 응답해 주셔서 감사합니다. 저희는 지금 콜랩1에 있습니다. 지금 당장 가능합니다.")
                                         .font(.sandoll(size: 14, weight: .medium))
                                         .padding(.vertical, 5)
                                         .padding(.horizontal, 11)
@@ -107,9 +106,9 @@ struct Chat: View {
                     if showNextMessage >= 2 {
                         HStack {
                             HStack {
-                                Circle()
+                                Image("Leeo")
                                     .frame(width: 48, height: 48)
-                                    .foregroundColor(Color(hex: "D9D9D9"))
+                                    .cornerRadius(24)
                                 
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text("리이오")
@@ -159,6 +158,19 @@ struct Chat: View {
                                 Text("(와)과 멘토링 약속을 잡았어요.")
                                     .font(.sandoll(size: 14, weight: .medium))
                                     .foregroundColor(Color(hex: "292929"))
+                                
+                                Spacer()
+                                
+                                NavigationLink {
+                                    MentoringWithLeeo()
+                                } label: {
+                                    Image(systemName: "play.circle.fill")
+                                        .symbolRenderingMode(.palette)
+                                        .foregroundStyle(.white, Color(hex: "F6D555"))
+                                        .font(.sandoll(size: 25, weight: .medium))
+                                        .padding(.trailing, 10
+                                        )
+                                }
                             }
                             .padding(.leading, 28)
                         }
@@ -233,11 +245,13 @@ struct Chat: View {
                                             showNextMessage += 1
                                             if showNextMessage == 1 {
                                                 avPlayer[0].pause()
+                                                avPlayer[1].seek(to: .zero)
                                                 avPlayer[1].play()
                                                 avPlayer[2].pause()
                                             } else if showNextMessage >= 2 {
                                                 avPlayer[0].pause()
                                                 avPlayer[1].pause()
+                                                avPlayer[2].seek(to: .zero)
                                                 avPlayer[2].play()
                                             }
                                         } label: {
@@ -279,12 +293,15 @@ struct Chat: View {
             }
             .ignoresSafeArea()
             .onAppear {
+                avPlayer[0].seek(to: .zero)
                 avPlayer[0].play()
                 avPlayer[1].pause()
                 avPlayer[2].pause()
             }
             .navigationBarBackButtonHidden(true)
             .navigationBarItems(leading: btnBack)
+            .navigationBarTitle("리이오", displayMode: .inline)
+            .navigationBarItems(trailing: Image(systemName: "pencil.circle").foregroundColor( showNextMessage >= 2 ? .black : .clear))
             .toolbar(showTabBarButton ? .visible : .hidden, for: .tabBar)
         } else {
             // Fallback on earlier versions

--- a/Mentors.swiftpm/ContentView.swift
+++ b/Mentors.swiftpm/ContentView.swift
@@ -2,8 +2,9 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var index: Int = 2
-    
+    @State var isShowRecordButton: Bool = false
     var body: some View {
+        
         //탭바
         //홈 버튼이 기본 활성화가 되어야 해요
         //각 버튼에서 링크 연결 필요한 것들이 있어요
@@ -22,18 +23,18 @@ struct ContentView: View {
                         Image(systemName: "square.on.square.badge.person.crop")
                     }
                     .tag(1)
-                Home()
+                Home(isShowRecordButton: $isShowRecordButton)
                     .toolbar(.hidden, for: .automatic)
                     .tabItem {
                         Image(systemName: "house")
                     }
                     .tag(2)
                 NavigationView {
-                    Chat()
+                    Chat(isShowRecordButton: $isShowRecordButton)
                 }
                 .tabItem {
                     NavigationLink {
-                        Chat()
+                        Chat(isShowRecordButton: $isShowRecordButton)
                             .toolbar(.hidden, for: .tabBar)
                     } label: {
                         Image(systemName: "ellipsis.message")

--- a/Mentors.swiftpm/Home.swift
+++ b/Mentors.swiftpm/Home.swift
@@ -11,7 +11,7 @@ struct Home: View {
     @State private var isNavigateToRecord: Bool = false
     @State private var isNavigateToSending: Bool = false
     @State private var isNavigateToSummary: Bool = false
-    @State var isShowRecordButton: Bool = false
+    @Binding var isShowRecordButton: Bool
     
     var body: some View {
         NavigationView {
@@ -66,11 +66,5 @@ struct Home: View {
             .padding(.horizontal, 26)
         }
         .navigationBarBackButtonHidden(true)
-    }
-}
-
-struct home_Previews: PreviewProvider {
-    static var previews: some View {
-        Home()
     }
 }

--- a/Mentors.swiftpm/Home.swift
+++ b/Mentors.swiftpm/Home.swift
@@ -11,6 +11,7 @@ struct Home: View {
     @State private var isNavigateToRecord: Bool = false
     @State private var isNavigateToSending: Bool = false
     @State private var isNavigateToSummary: Bool = false
+    @State var isShowRecordButton: Bool = false
     
     var body: some View {
         NavigationView {
@@ -23,17 +24,19 @@ struct Home: View {
                 
                 //진행 중인 멘토링 기록하기
                 // TODO: 멘토링 시작 이후에 활성화되도록 만들어야해요
-                NavigationLink(isActive: $isNavigateToRecord) {
-                    Record()
-                } label: {
-                        Text("진행 중인 멘토링 기록하기")
-                            .fontWeight(.bold)
-                            .font(Font.custom("Apple SD Gothic Neo", size: 20))
-                            .frame(maxWidth: 400, minHeight: 48)
-                            .background(Color(hex: "E8585E"))
-                            .foregroundColor(Color.init(hex: "F9F9F9"))
-                            .cornerRadius(10)
-                            .padding(.top, 40)
+                if isShowRecordButton {
+                    NavigationLink(isActive: $isNavigateToRecord) {
+                        Record()
+                    } label: {
+                            Text("진행 중인 멘토링 기록하기")
+                                .fontWeight(.bold)
+                                .font(Font.custom("Apple SD Gothic Neo", size: 20))
+                                .frame(maxWidth: 400, minHeight: 48)
+                                .background(Color(hex: "E8585E"))
+                                .foregroundColor(Color.init(hex: "F9F9F9"))
+                                .cornerRadius(10)
+                                .padding(.top, 40)
+                    }
                 }
                 
                 //내비게이션

--- a/Mentors.swiftpm/MentoringWithLeeo.swift
+++ b/Mentors.swiftpm/MentoringWithLeeo.swift
@@ -13,10 +13,30 @@ struct MentoringWithLeeo: View {
     let avPlayer = AVPlayer(url:  Bundle.main.url(forResource: "Mentoring", withExtension: "mp4")!)
     
     var body: some View {
-        VideoPlayer(player: avPlayer)
-            .onDisappear {
-                avPlayer.isMuted = false
+        if #available(iOS 16.0, *) {
+            VStack {
+                Spacer()
+                
+                VideoPlayer(player: avPlayer)
+                    .onDisappear {
+                        avPlayer.isMuted = false
+                    }
+                
+                Spacer()
             }
+            .ignoresSafeArea()
+            .background(Color(.black))
+            .onAppear {
+                avPlayer.play()
+            }
+            .onDisappear {
+                avPlayer.pause()
+                avPlayer.seek(to: .zero)
+            }
+            .toolbar(.hidden, for: .tabBar)
+        } else {
+            // Fallback on earlier versions
+        }
     }
 }
 

--- a/Mentors.swiftpm/SendingEightView.swift
+++ b/Mentors.swiftpm/SendingEightView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct SendingEightView: View {
     @Environment(\.presentationMode) var presentationMode
+    @State private var isPopupShowing: Bool = false
+    
     var body: some View {
         
         ScrollView {
@@ -48,7 +50,9 @@ struct SendingEightView: View {
                     }
                     
                     // VStack-Button(4)
-                    Button(action: {}) {
+                    Button(action: {
+                        isPopupShowing = true
+                    }) {
                         HStack {
                             MentorTag(mentorKoreanName: "리이오", mentorEnglishName: "Leeo", mentorStrength: "Tech", strengthColorCode: "CEE1F3")
                         }
@@ -98,22 +102,64 @@ struct SendingEightView: View {
                     .padding(.bottom, 40)
                     
                 }
-                
-                //VStack-Button
-                Button(action:{
-                    NavigationUtil.popToRootView()
-                }) {
-                    Text("다음")
-                        .font(.sandoll(size: 18, weight: .semibold))
-                        .foregroundColor(Color(hex: "292929"))
-                        .fixedSize()
-                        .frame(width: 350, height: 48)
-                        .background(Color(hex: "F6D555"))
-                        .cornerRadius(10)
-                }
-                
             }
             .padding()
+        }
+        .popup(isPresented: $isPopupShowing) {
+            VStack(alignment: .center) {
+                Text("'리이오' 멘토에게 사연을 보낼까요?")
+                    .font(.sandoll(size: 20, weight: .semibold))
+                    .padding(.top, 55)
+                    .foregroundColor(Color(hex: "292929"))
+                Text("멘토가 해당 사연을 열람하기 전까지는\n수정이 가능해요.")
+                    .font(.sandoll(size: 16, weight: .semibold))
+                    .foregroundColor(Color(hex: "292929"))
+                    .padding(.top, 18)
+                    .multilineTextAlignment(.center)
+                
+                HStack {
+                    Button {
+                        isPopupShowing = false
+                        // TODO: pop to root view
+                    } label: {
+                        Text("네, 보낼게요")
+                            .padding(.vertical, 15)
+                            .padding(.horizontal, 12)
+                            .background(Color(hex: "F6D555"))
+                            .font(.sandoll(size: 18, weight: .semibold))
+                            .foregroundColor(Color(hex: "292929"))
+                            .cornerRadius(10)
+                    }
+                    
+                    Button {
+                        isPopupShowing = false
+                    } label: {
+                        Text("다시 고를래요")
+                            .padding(.vertical, 15)
+                            .padding(.horizontal, 12)
+                            .background(Color(hex: "E5E2D7"))
+                            .font(.sandoll(size: 18, weight: .semibold))
+                            .foregroundColor(Color(hex: "292929"))
+                            .cornerRadius(10)
+                            .padding(.leading, 15)
+                    }
+                }
+                .padding(.top, 44)
+                .padding(.bottom, 20)
+            }
+            .frame(width: UIScreen.main.bounds.width-64)
+            .frame(minHeight: 247)
+            .background(Color(hex: "F7F5EF"))
+            .cornerRadius(10)
+            .overlay {
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color(hex: "F6D555"), lineWidth: 4)
+                    .background(Color("F9F9F9"))
+            }
+        } customize: {
+            $0.animation(.spring())
+                .closeOnTapOutside(true)
+                .backgroundColor(.black.opacity(0.5))
         }
         .navigationBarBackButtonHidden(true)
     }

--- a/Mentors.swiftpm/SendingEightView.swift
+++ b/Mentors.swiftpm/SendingEightView.swift
@@ -120,7 +120,7 @@ struct SendingEightView: View {
                 HStack {
                     Button {
                         isPopupShowing = false
-                        // TODO: pop to root view
+                        NavigationUtil.popToRootView()
                     } label: {
                         Text("네, 보낼게요")
                             .padding(.vertical, 15)


### PR DESCRIPTION
- Sending 완료되면 Root View로 pop
- '(현재 진행중인) 멘토링 기록하기' 버튼이 약속을 잡은 후에 뜨도록 수정
- 멘토를 선택하면 확정하겠냐는 팝업
- 멘토링 상황 재현 UI 구현